### PR TITLE
Fix get_duration() on FreeBSD

### DIFF
--- a/polybar-scripts/openweathermap-fullfeatured/openweathermap-fullfeatured.sh
+++ b/polybar-scripts/openweathermap-fullfeatured/openweathermap-fullfeatured.sh
@@ -26,7 +26,12 @@ get_icon() {
 
 get_duration() {
 
-    date --date="@$1" -u +%H:%M
+    osname=$(uname -s)
+    
+    case $osname in
+        *BSD) date -r "$1" -u +%H:%M;;
+        *) date --date="@$1" -u +%H:%M;;
+    esac
 
 }
 


### PR DESCRIPTION
The date command has different options on FreeBSD systems.