### PR TITLE
Fixed cut error in info-redshift-temp.sh

### DIFF
--- a/polybar-scripts/info-redshift-temp/info-redshift-temp.sh
+++ b/polybar-scripts/info-redshift-temp/info-redshift-temp.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ "$(pgrep -x redshift)" ]; then
-    temp=$(redshift -p 2> /dev/null | grep temp | cut -d " " -f 3 | tr -d "[:alpha:]")
+    temp=$(redshift -p 2> /dev/null | grep temp | cut -d ":" -f 2 | tr -dc "[:digit:]")
 
     if [ -z "$temp" ]; then
         echo "%{F#65737E} #"

--- a/polybar-scripts/info-redshift-temp/info-redshift-temp.sh
+++ b/polybar-scripts/info-redshift-temp/info-redshift-temp.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 if [ "$(pgrep -x redshift)" ]; then
-    temp=$(redshift -p 2> /dev/null | grep temp | cut -d " " -f 2 | tr -d "[:alpha:]")
+    temp=$(redshift -p 2> /dev/null | grep temp | cut -d " " -f 3 | tr -d "[:alpha:]")
 
     if [ -z "$temp" ]; then
         echo "%{F#65737E} #"


### PR DESCRIPTION
This script previously fetched ':' and tried to compare it to an integer. Changed it so that it fetches for example '5000K' and then cuts 'K' instead of the ':' from '..temperature: 5000K'.

Changed the command from
$ redshift -p 2> /dev/null | grep temp | cut -d " " -f 2 | tr -d "[:alpha:]"
to
$ redshift -p 2> /dev/null | grep temp | cut -d " " -f 3 | tr -d "[:alpha:]"

Explanation:
$ redshift -p 2> /dev/null | grep temp
yields
Color temperature: 5000K
piped into 'cut -d " " -f 2' gives
:
while piped into 'cut -d " " -f 3' gives
5000K
which is what we want.

Hope this helps!