### PR TITLE
Control the active player

### DIFF
--- a/polybar-scripts/player-mpris-tail/README.md
+++ b/polybar-scripts/player-mpris-tail/README.md
@@ -19,7 +19,7 @@ This script displays the current track and the play-pause status without polling
 type = custom/script
 exec = ~/polybar-scripts/player-mpris-tail.py
 tail = true
-click-left = playerctl previous
-click-right = playerctl next
-click-middle = playerctl play-pause
+click-left = ~/polybar-scripts/player-ctrl.sh previous
+click-right = ~/polybar-scripts/player-ctrl.sh next
+click-middle = ~/polybar-scripts/player-ctrl.sh play-pause
 ```

--- a/polybar-scripts/player-mpris-tail/player-ctrl.sh
+++ b/polybar-scripts/player-mpris-tail/player-ctrl.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+function listPlayers {
+    echo "$(dbus-send --session --dest=org.freedesktop.DBus \
+        --type=method_call --print-reply /org/freedesktop/DBus \
+        org.freedesktop.DBus.ListNames | grep org.mpris.MediaPlayer2 |
+        awk -F\" '{print $2}' | cut -d '.' -f4- )"
+}
+
+function getPlayerStatus {
+    playerctl --player="$1" status
+}
+
+function getActivePlayer {
+    players=($(listPlayers))
+    for player in ${players[@]}; do
+        if [ "$(getPlayerStatus "${player}")" == "Playing" ]; then
+            playing=$player
+	fi
+    done
+    for player in ${players[@]}; do
+        if [ "$(getPlayerStatus "${player}")" == "Paused" ]; then
+            paused=$player
+	fi
+    done
+    if [ -n "$playing" ]; then
+        echo "$playing"
+    elif [ -n "$paused" ]; then
+        echo "$paused"
+    else
+	# Return last (newest?) player
+        echo ${players[@]: -1}
+    fi
+}
+
+if [ "$1" == "--get-active" ]; then
+  getActivePlayer
+else
+  exec playerctl --player="$(getActivePlayer)" "$@"
+fi

--- a/polybar-scripts/player-mpris-tail/player-mpris-tail.py
+++ b/polybar-scripts/player-mpris-tail/player-mpris-tail.py
@@ -34,7 +34,8 @@ def getActivePlayer():
         return playing[-1]
     if len(paused):
         return paused[-1]
-    return players.name[-1]
+    if len(players)
+        return players.name[-1]
 
 class PlayerStatus:
     def __init__(self):

--- a/polybar-scripts/player-mpris-tail/player-mpris-tail.py
+++ b/polybar-scripts/player-mpris-tail/player-mpris-tail.py
@@ -27,12 +27,14 @@ def getPlayerStatus(playername):
     )
 
 def getActivePlayer():
-    playing = [ player for player in listPlayers() if getPlayerStatus(player) == 'Playing' ]
-    paused  = [ player for player in listPlayers() if getPlayerStatus(player) == 'Paused' ]
+    players = [ { 'name': player, 'status': getPlayerStatus(player) } for player in listPlayers() ]
+    playing = [ player['name'] for player in players if player['status'] == 'Playing' ]
+    paused  = [ player['name'] for player in players if player['status'] == 'Paused' ]
     if len(playing):
-        return playing[0]
+        return playing[-1]
     if len(paused):
-        return paused[0]
+        return paused[-1]
+    return players.name[-1]
 
 class PlayerStatus:
     def __init__(self):

--- a/polybar-scripts/player-mpris-tail/player-mpris-tail.py
+++ b/polybar-scripts/player-mpris-tail/player-mpris-tail.py
@@ -34,7 +34,7 @@ def getActivePlayer():
         return playing[-1]
     if len(paused):
         return paused[-1]
-    if len(players)
+    if len(players):
         return players[-1]['name']
 
 class PlayerStatus:

--- a/polybar-scripts/player-mpris-tail/player-mpris-tail.py
+++ b/polybar-scripts/player-mpris-tail/player-mpris-tail.py
@@ -35,7 +35,7 @@ def getActivePlayer():
     if len(paused):
         return paused[-1]
     if len(players)
-        return players.name[-1]
+        return players[-1]['name']
 
 class PlayerStatus:
     def __init__(self):


### PR DESCRIPTION
Added wrapper script for playerctl that will auto-pick the same player for control as player-mpris-tail.py is displaying.
Optimised picking the right player.
Changed picking order to pick the last available, to try to always get the newest opened player.