### PR TITLE
hackspeed: some little tweaks

### DIFF
--- a/polybar-scripts/info-hackspeed/README.md
+++ b/polybar-scripts/info-hackspeed/README.md
@@ -23,7 +23,7 @@ tail = true
 
 ## Setup
 
-You may have to set up your keyboard. Set the environment variable `KEYBOARD_ID` (see Configuration below) or change the default value in the script. You can find your keyboard description with `xinput list --short`.
+If after 20 seconds the value stays at 0 even though you're typing, you may have to configure the name of your keyboard. Change the setting `KEYBOARD_ID` (see Configuration below) in the script. You can find your keyboard description with `xinput list --short`.
 
 
 ## Configuration

--- a/polybar-scripts/info-hackspeed/README.md
+++ b/polybar-scripts/info-hackspeed/README.md
@@ -30,7 +30,6 @@ If after 20 seconds the value stays at 0 even though you're typing, you may have
 
 * `KEYBOARD_ID`: name of your keyboard. See Setup above. Default: `AT Translated Set 2 keyboard`
 * `METRIC`: either `cpm` (characters per minute) of `wpm` ([words per minute, 1 word = 5 characters](https://en.wikipedia.org/wiki/Words_per_minute)). Default: `cpm`
-* `ICON`: label to prefix to the count. Default: `#`
-* `FORMAT`: format string according to which the metric will be output. Default: `$ICON %d $METRIC`
+* `FORMAT`: format string according to which the metric will be output. Default: `# %d $METRIC`
 * `INTERVAL`: amount of seconds to gather data. Default: 20
 * `LAYOUT`: keyboard layout, to be able to only count letters and numbers. Currently supported are `qwerty` and `azerty`. If you have a different layout, please contribute a condition for it! See the script's source code. Use the special value `dontcare` to count all keys, not just letters and numbers. Default: `qwerty`

--- a/polybar-scripts/info-hackspeed/info-hackspeed.sh
+++ b/polybar-scripts/info-hackspeed/info-hackspeed.sh
@@ -5,8 +5,7 @@ KEYBOARD_ID="AT Translated Set 2 keyboard"
 # cpm: characters per minute
 # wpm: words per minute (1 word = 5 characters)
 METRIC=cpm
-ICON="#"
-FORMAT="$ICON %d $METRIC"
+FORMAT="# %d $METRIC"
 
 INTERVAL=20
 


### PR DESCRIPTION
* Remove env var mention in hackspeed README:

> Set the environment variable KEYBOARD_ID (see Configuration below) or change the default value in the script.

This is wrong. An oversight while separating my changes into two commits, my bad.

* Remove variable ICON:

This isn't needed any more. It's easier to just change the variable FORMAT now that environment variables aren't supported.