### PR TITLE
Fix inbox-reddit

### DIFF
--- a/polybar-scripts/inbox-reddit/inbox-reddit.sh
+++ b/polybar-scripts/inbox-reddit/inbox-reddit.sh
@@ -3,6 +3,11 @@
 url="your url here"
 unread=$(curl -sf "$url" | jq '.["data"]["children"] | length')
 
+case "$unread" in
+    ''|*[!0-9]*)
+	unread=0
+esac;
+
 if [ "$unread" -gt 0 ]; then
    echo "#1 $unread"
 else


### PR DESCRIPTION
First of all, a big thank you for the many scripts ideas you submit. I notified an error in the `inbox-reddit.sh` script about retrieving unread messages from our Reddit account.

Indeed, it frequently happened to have this error message:
`./inbox-reddit.sh: line 6: [: : integer expression expected`

I therefore took the trouble to find a solution and also to modify certain minor elements.