### PR TITLE
The player-moc will not disappear when the moc stops playing music and its text too wide.

### DIFF
--- a/polybar-scripts/player-moc/README.md
+++ b/polybar-scripts/player-moc/README.md
@@ -4,14 +4,17 @@ A small Script that shows the current song.
 
 You can also control mocp.
 
+*Note: You can change the maximum size of the text to be shown in the module by changing the value in "label-maxlen"
 
 ## Module
 
 ```ini
 [module/player-moc]
 type = custom/script
+format = <label>
+label-maxlen = 40
 exec = ~/polybar-scripts/player-moc.sh
-interval = 5
+interval = 1
 click-left = mocp -f
 click-right = mocp -r
 click-middle = mocp -P

--- a/polybar-scripts/player-moc/player-moc.sh
+++ b/polybar-scripts/player-moc/player-moc.sh
@@ -15,7 +15,7 @@
 #        %b         Bitrate
 #        %r         Rate
 
-if [ $(mocp -Q %state) != "STOP" ]
+if [ "$(mocp -Q %state)" != "STOP" ]
 then
     echo "$(mocp -Q %song) - $(mocp -Q %album)"
 else 

--- a/polybar-scripts/player-moc/player-moc.sh
+++ b/polybar-scripts/player-moc/player-moc.sh
@@ -1,3 +1,23 @@
 #!/bin/sh
 
-echo "$(mocp -Q %artist) - $(mocp -Q %song) ($(mocp -Q %album))"
+# Change according to information you wish to show in your polybar:
+#        %state     State
+#        %file       File
+#        %title     Title
+#        %artist    Artist
+#        %song      SongTitle
+#        %album     Album
+#        %tt        TotalTime
+#        %tl        TimeLeft
+#        %ts        TotalSec
+#        %ct        CurrentTime
+#        %cs        CurrentSec
+#        %b         Bitrate
+#        %r         Rate
+
+if [ $(mocp -Q %state) != "STOP" ]
+then
+    echo "$(mocp -Q %song) - $(mocp -Q %album)"
+else 
+    echo ""    
+fi


### PR DESCRIPTION
When I press an 's' on the keyboard for the mocp to stop playing, the module keeps displaying information from the last song, it would not be better to add an if in the shell script to when the mocp stops it printing an empty echo, or something else, only to update the information in the module?

As it says in the wiki:
"If you want that your module disappear from the bar in some case your output has to be created with echo" "Otherwise an outdated output is still on the bar. See # 504."

And one more thing, which I think I could improve on, is that the previous module allowed a wide text to appear on the bar and disrupt the placement of the other adjacent modules, so I added the label-maxlen to correct that.
I also changed the interval because I believe that 5 seconds is too much for the information to be updated when the next song starts, so I would recommend a lower value.

I really like moc, so I make this pull request to try to make an improvement, but only if you think it's necessary. If you consider this pull request, you can change what you need, such as the value of the range or information such as album, artist or music to display in the script by default. I personally think only the name of the song and the album are needed to show.

~Google translator