### PR TITLE
Fix openweathermap scripts for when the API returns more than icon

### DIFF
--- a/polybar-scripts/openweathermap-detailed/openweathermap-detailed.sh
+++ b/polybar-scripts/openweathermap-detailed/openweathermap-detailed.sh
@@ -44,9 +44,9 @@ else
 fi
 
 if [ ! -z "$weather" ]; then
-    weather_desc=$(echo "$weather" | jq -r ".weather[].description")
+    weather_desc=$(echo "$weather" | jq -r ".weather[0].description")
     weather_temp=$(echo "$weather" | jq ".main.temp" | cut -d "." -f 1)
-    weather_icon=$(echo "$weather" | jq -r ".weather[].icon")
+    weather_icon=$(echo "$weather" | jq -r ".weather[0].icon")
 
     echo "$(get_icon "$weather_icon")" "$weather_desc", "$weather_temp$SYMBOL"
 fi

--- a/polybar-scripts/openweathermap-forecast/openweathermap-forecast.sh
+++ b/polybar-scripts/openweathermap-forecast/openweathermap-forecast.sh
@@ -46,10 +46,10 @@ fi
 
 if [ ! -z "$current" ] && [ ! -z "$forecast" ]; then
     current_temp=$(echo "$current" | jq ".main.temp" | cut -d "." -f 1)
-    current_icon=$(echo "$current" | jq -r ".weather[].icon")
+    current_icon=$(echo "$current" | jq -r ".weather[0].icon")
 
     forecast_temp=$(echo "$forecast" | jq ".list[].main.temp" | cut -d "." -f 1)
-    forecast_icon=$(echo "$forecast" | jq -r ".list[].weather[].icon")
+    forecast_icon=$(echo "$forecast" | jq -r ".list[].weather[0].icon")
 
     if [ "$current_temp" -gt "$forecast_temp" ]; then
         trend=""

--- a/polybar-scripts/openweathermap-fullfeatured/openweathermap-fullfeatured.sh
+++ b/polybar-scripts/openweathermap-fullfeatured/openweathermap-fullfeatured.sh
@@ -57,10 +57,10 @@ fi
 
 if [ ! -z "$current" ] && [ ! -z "$forecast" ]; then
     current_temp=$(echo "$current" | jq ".main.temp" | cut -d "." -f 1)
-    current_icon=$(echo "$current" | jq -r ".weather[].icon")
+    current_icon=$(echo "$current" | jq -r ".weather[0].icon")
 
     forecast_temp=$(echo "$forecast" | jq ".list[].main.temp" | cut -d "." -f 1)
-    forecast_icon=$(echo "$forecast" | jq -r ".list[].weather[].icon")
+    forecast_icon=$(echo "$forecast" | jq -r ".list[].weather[0].icon")
 
 
     if [ "$current_temp" -gt "$forecast_temp" ]; then

--- a/polybar-scripts/openweathermap-simple/openweathermap-simple.sh
+++ b/polybar-scripts/openweathermap-simple/openweathermap-simple.sh
@@ -45,7 +45,7 @@ fi
 
 if [ ! -z "$weather" ]; then
     weather_temp=$(echo "$weather" | jq ".main.temp" | cut -d "." -f 1)
-    weather_icon=$(echo "$weather" | jq -r ".weather[].icon")
+    weather_icon=$(echo "$weather" | jq -r ".weather[0].icon")
 
     echo "$(get_icon "$weather_icon")" "$weather_temp$SYMBOL"
 fi


### PR DESCRIPTION
According to the [OpenWeatherMap API documentation](https://openweathermap.org/weather-data), it is possible for it to return more than one object in the `weather` array. Example:

```json
...
"weather":[
                 {"id":520,"main":"rain","description":"light intensity shower rain","icon":"09d"},
                 {"id":500,"main":"rain","description":"light rain","icon":"10d"},
                 {"id":701,"main":"mist","description":"mist","icon":"50d"}
              ],
...
```

The jq query used to get the icon from the API response would return a list of all the icons in each of the weather objects and pass it to the `get_icon` function. The function would not identify it as a valid value and return the default one instead.

To fix this, I changed the query to only return the icon of the first object in the list.
