### PR TITLE
system-uptime-pretty: replace 'weeks' with 'w'

### DIFF
--- a/polybar-scripts/system-uptime-pretty/system-uptime-pretty.sh
+++ b/polybar-scripts/system-uptime-pretty/system-uptime-pretty.sh
@@ -1,3 +1,3 @@
 #!/bin/sh
 
-uptime --pretty | sed 's/up //' | sed 's/\ years\?,/y/' | sed 's/\ days\?,/d/' | sed 's/\ hours\?,\?/h/' | sed 's/\ minutes\?/m/'
+uptime --pretty | sed 's/up //' | sed 's/\ years\?,/y/' | sed 's/\ weeks\?,/w/' | sed 's/\ days\?,/d/' | sed 's/\ hours\?,\?/h/' | sed 's/\ minutes\?/m/'


### PR DESCRIPTION
On my machine, `uptime --pretty` also outputs the week.  This PR replaces `weeks,` with `w`.