### PR TITLE
Fix headphone list-sink printing to Polybar

### DIFF
--- a/polybar-scripts/pulseaudio-tail/pulseaudio-tail.sh
+++ b/polybar-scripts/pulseaudio-tail/pulseaudio-tail.sh
@@ -17,7 +17,7 @@ volume_mute() {
 volume_print() {
     if pacmd list-sinks | grep active | head -n 1 | grep -q speaker; then
         icon="#1"
-    elif pacmd list-sinks | grep active | head -n 1 | grep headphones; then
+    elif pacmd list-sinks | grep active | head -n 1 | grep -q headphones; then
         icon="#2"
     else
         icon="#3"


### PR DESCRIPTION
Without the `-q` flag and with headphones connected, the command `pacmd list-sinks | grep active | head -n 1 | grep headphone` output: `ctive port: <analog-output-headphones>` is printed to Polybar every time the volume is changed.