### PR TITLE
mpris-tail: add configurable output format

### DIFF
--- a/polybar-scripts/player-mpris-tail/README.md
+++ b/polybar-scripts/player-mpris-tail/README.md
@@ -13,6 +13,7 @@ This script displays the current track and the play-pause status without polling
 
 ## Module
 
+Default output format
 ```ini
 [module/player-mpris-tail]
 type = custom/script
@@ -22,3 +23,19 @@ click-left = ~/polybar-scripts/player-ctrl.sh previous
 click-right = ~/polybar-scripts/player-ctrl.sh next
 click-middle = ~/polybar-scripts/player-ctrl.sh play-pause
 ```
+
+Custom output format
+```ini
+[module/player-mpris-tail]
+type = custom/script
+exec = ~/polybar-scripts/player-mpris-tail.py '{icon} {title}'
+tail = true
+click-left = ~/polybar-scripts/player-ctrl.sh previous
+click-right = ~/polybar-scripts/player-ctrl.sh next
+click-middle = ~/polybar-scripts/player-ctrl.sh play-pause
+```
+The format string supports the following tags:
+
+* `{icon}`: playing status icon
+* `{artist}`: artist name
+* `{title}`: song title

--- a/polybar-scripts/player-mpris-tail/player-mpris-tail.py
+++ b/polybar-scripts/player-mpris-tail/player-mpris-tail.py
@@ -38,7 +38,7 @@ def getActivePlayer():
         return players[-1]['name']
 
 class PlayerStatus:
-    def __init__(self):
+    def __init__(self, fmt='{icon}  {artist} - {title}'):
         self._player = None
         self._player_class = None
         self._player_name = None
@@ -48,6 +48,8 @@ class PlayerStatus:
         self._last_title = None
 
         self._last_status = ''
+
+        self._format = fmt
 
     def show(self):
         self._init_player()
@@ -100,7 +102,9 @@ class PlayerStatus:
 
     def _print_song(self):
         self._print_flush(
-            '{}  {} - {}'.format(self._icon, self._artist, self._title))
+            self._format.format(icon = self._icon,
+                                artist = self._artist,
+                                title = self._title))
 
     """
     Seems to assure print() actually prints when no terminal is connected
@@ -112,4 +116,7 @@ class PlayerStatus:
             sys.stdout.flush()
             self._last_status = status
 
-PlayerStatus().show()
+if len(sys.argv) == 2:
+    PlayerStatus(sys.argv[1]).show()
+else:
+    PlayerStatus().show()


### PR DESCRIPTION
Add the possibility of passing an argument to the python file to define the output format.

Currently supports tags for icon, artist and title.