### PR TITLE
Script: updates-arch-yay

### DIFF
--- a/polybar-scripts/updates-arch-yay/README.md
+++ b/polybar-scripts/updates-arch-yay/README.md
@@ -5,6 +5,14 @@ Includes optional click actions to display a notification of available updates
 and another to display a GUI list of available packages and trigger the update
 of those the user selects.
 
+## Screenshot Previews
+### Module
+![Polybar Module With Updates](https://i.imgur.com/ZMap2mN.png)
+
+### Package Update GUI
+![Package Update GUI](https://i.imgur.com/mXIdvvf.png)
+
+
 ## Dependencies
 
 Requires 'yay'.

--- a/polybar-scripts/updates-arch-yay/README.md
+++ b/polybar-scripts/updates-arch-yay/README.md
@@ -1,17 +1,43 @@
 # Script: updates-arch-yay
 
-A script that shows the total available updates for Arch Linux using Yay.
+A script that shows the total available updates for Arch Linux using `yay`.
 
 
 ## Dependencies
 
 Requires 'yay'.
 
+Optional left and right click actions required:
+  * `i3wm`, window manager
+  * `notify-send`, broadcast notifcation
+  * `zenity`, display table for package selection
+  * `termite`, terminal to execute updates with output
+
 ## Module
 
 ```ini
-[module/updates-arch-aur]
-type = custom/script
-exec = ~/polybar-scripts/updates-arch-yay/updates-arch-yay.sh
-interval = 600
+ [module/updates]
+ type = custom/script
+ exec = ~/code/polybar-scripts/polybar-scripts/updates-arch-yay/updates-arch-yay.sh
+ interval = 600
+ click-left = i3-msg exec ~/code/polybar-scripts/polybar-scripts/updates-arch-yay/notify-updates.sh
+ click-right = i3-msg exec ~/code/polybar-scripts/polybar-scripts/updates-arch-yay/prompt-updates.sh
+```
+### Notify Updates
+
+Left clicking on the module will trigger a system notifcation with a list of
+package names for which there are currently updates available.
+
+### Prompt for Updates
+
+Right clicking on the module will trigger the display of a table to allow the
+selection of which packages to upgrade, and automatically start their upgrade
+through `yay`.
+
+## i3 Configuration
+
+Show package updates from Polybar in floating window
+
+```
+ for_window [instance="^package-update$" class="^Termite$"] floating enable, move position center 
 ```

--- a/polybar-scripts/updates-arch-yay/README.md
+++ b/polybar-scripts/updates-arch-yay/README.md
@@ -1,7 +1,9 @@
 # Script: updates-arch-yay
 
 A script that shows the total available updates for Arch Linux using `yay`.
-
+Includes optional click actions to display a notification of available updates
+and another to display a GUI list of available packages and trigger the update
+of those the user selects.
 
 ## Dependencies
 

--- a/polybar-scripts/updates-arch-yay/README.md
+++ b/polybar-scripts/updates-arch-yay/README.md
@@ -15,7 +15,7 @@ of those the user selects.
 
 ## Dependencies
 
-Requires 'yay'.
+Requires `yay`.
 
 Optional left and right click actions required:
   * `i3wm`, window manager

--- a/polybar-scripts/updates-arch-yay/README.md
+++ b/polybar-scripts/updates-arch-yay/README.md
@@ -1,0 +1,17 @@
+# Script: updates-arch-yay
+
+A script that shows the total available updates for Arch Linux using Yay.
+
+
+## Dependencies
+
+Requires 'yay'.
+
+## Module
+
+```ini
+[module/updates-arch-aur]
+type = custom/script
+exec = ~/polybar-scripts/updates-arch-yay/updates-arch-yay.sh
+interval = 600
+```

--- a/polybar-scripts/updates-arch-yay/notify-updates.sh
+++ b/polybar-scripts/updates-arch-yay/notify-updates.sh
@@ -1,0 +1,2 @@
+#! /bin/sh
+yay -Qu | awk '{print $1;}' | sed 's/\x1b\[[0-9;]*m//g' | xargs -0 notify-send -t 10000 --hint=int:suppress-sound:0 "Pending Package Updates"

--- a/polybar-scripts/updates-arch-yay/prompt-updates.sh
+++ b/polybar-scripts/updates-arch-yay/prompt-updates.sh
@@ -1,0 +1,18 @@
+#! /bin/bash
+ALL=$(yay -Qu | sed 's/\x1b\[[0-9;]*m//g' | sed 's/->//g' | sed 's/^/TRUE /g')
+UPDATE=$(zenity --list \
+  --width=500 --height=400 \
+  --text="Select updates to install:" \
+  --checklist \
+  --separator=" " \
+  --title="The following pacakges are outdated" \
+  --column="Update" --column="Package Name" --column="Previous Version" --column="Current Version" \
+  $ALL)
+if [[ -z "${UPDATE// }" ]]
+then
+    exit 1
+else
+    RESULT=$(termite --name package-update -e "yay -S --noconfirm $UPDATE")
+fi
+echo "Requesting Update: $UPDATE"
+exit 0

--- a/polybar-scripts/updates-arch-yay/updates-arch-yay.sh
+++ b/polybar-scripts/updates-arch-yay/updates-arch-yay.sh
@@ -1,0 +1,17 @@
+#!/bin/sh
+# List all updates available from Yay (includes AUR)
+
+# Sync package list first
+yay -Sy > /dev/null
+
+# Get list and count of updates
+if ! updates=$(yay -Qu | wc -l); then
+    updates=0
+fi
+
+# Print the available updates if more than 0
+if [ "$updates" -gt 0 ]; then
+    echo "  $updates"
+else
+    echo ""
+fi


### PR DESCRIPTION
A script that shows the total available updates for Arch Linux using yay. Includes optional click actions to display a notification of available updates and another to display a GUI list of available packages and trigger the update of those the user selects.