### PR TITLE
pulseaudio-tail: Add default sink

### DIFF
--- a/polybar-scripts/pulseaudio-tail/pulseaudio-tail.sh
+++ b/polybar-scripts/pulseaudio-tail/pulseaudio-tail.sh
@@ -1,6 +1,11 @@
 #!/bin/sh
 
-sink=0
+### Leave this variable unset if you want to use the default sink
+#sink=0
+
+get_default_sink() {
+    sink=$(pacmd list-sinks | sed -n '/\* index:/ s/.*: //p')
+}
 
 volume_up() {
     pactl set-sink-volume $sink +1%
@@ -15,9 +20,10 @@ volume_mute() {
 }
 
 volume_print() {
-    if pacmd list-sinks | grep active | head -n 1 | grep -q speaker; then
+    active_port=$(pacmd list-sinks | sed -n "/index: $sink/,/index:/p" | grep active)
+    if echo "$active_port" | grep -q speaker; then
         icon="#1"
-    elif pacmd list-sinks | grep active | head -n 1 | grep -q headphones; then
+    elif echo "$active_port" | grep -q headphones; then
         icon="#2"
     else
         icon="#3"
@@ -36,12 +42,19 @@ listen() {
     volume_print
 
     pactl subscribe | while read -r event; do
-        if echo "$event" | grep -q "#$sink"; then
+        if echo "$event" | grep -q "sink\ #$sink$"; then
+            volume_print
+        elif [ "$use_default_sink" ] && echo "$event" | grep -q "'change'\ on\ server"; then
+            get_default_sink
             volume_print
         fi
     done
 }
 
+if [ -z "$sink" ]; then
+    use_default_sink=true
+    get_default_sink
+fi
 case "$1" in
     --up)
         volume_up

--- a/polybar-scripts/pulseaudio-tail/pulseaudio-tail.sh
+++ b/polybar-scripts/pulseaudio-tail/pulseaudio-tail.sh
@@ -8,15 +8,15 @@ get_default_sink() {
 }
 
 volume_up() {
-    pactl set-sink-volume $sink +1%
+    pactl set-sink-volume "$sink" +1%
 }
 
 volume_down() {
-    pactl set-sink-volume $sink -1%
+    pactl set-sink-volume "$sink" -1%
 }
 
 volume_mute() {
-    pactl set-sink-mute $sink toggle
+    pactl set-sink-mute "$sink" toggle
 }
 
 volume_print() {
@@ -29,12 +29,12 @@ volume_print() {
         icon="#3"
     fi
 
-    muted=$(pamixer --sink $sink --get-mute)
+    muted=$(pamixer --sink "$sink" --get-mute)
 
     if [ "$muted" = true ]; then
         echo "$icon --"
     else
-        echo "$icon $(pamixer --sink $sink --get-volume)"
+        echo "$icon $(pamixer --sink "$sink" --get-volume)"
     fi
 }
 
@@ -42,9 +42,9 @@ listen() {
     volume_print
 
     pactl subscribe | while read -r event; do
-        if echo "$event" | grep -q "sink\ #$sink$"; then
+        if echo "$event" | grep -q "sink #$sink$"; then
             volume_print
-        elif [ "$use_default_sink" ] && echo "$event" | grep -q "'change'\ on\ server"; then
+        elif [ "$use_default_sink" ] && echo "$event" | grep -q "'change' on server"; then
             get_default_sink
             volume_print
         fi


### PR DESCRIPTION
This PR makes it possible to track the default sink.
Right now pulseaudio-tail uses only one sink, which is defined by the $sink variable. But that has some limitations. E.g. users that have more than one sound card may want to display the sink that is active.