### PR TITLE
Make player-moc use filename if no song name

### DIFF
--- a/polybar-scripts/player-moc/player-moc.sh
+++ b/polybar-scripts/player-moc/player-moc.sh
@@ -2,6 +2,7 @@
 
 if [ "$(mocp -Q %state)" != "STOP" ];then
     SONG=$(mocp -Q %song)
+    
     if [ -z "$SONG" ]; then
         basename "$(mocp -Q %file)"
     else

--- a/polybar-scripts/player-moc/player-moc.sh
+++ b/polybar-scripts/player-moc/player-moc.sh
@@ -2,11 +2,11 @@
 
 if [ "$(mocp -Q %state)" != "STOP" ];then
     SONG=$(mocp -Q %song)
-    
-    if [ -z "$SONG" ]; then
-        basename "$(mocp -Q %file)"
-    else
+        
+    if [ -n "$SONG" ]; then
         echo "$SONG - $(mocp -Q %album)"
+    else
+        basename "$(mocp -Q %file)"
     fi
 else
     echo ""

--- a/polybar-scripts/player-moc/player-moc.sh
+++ b/polybar-scripts/player-moc/player-moc.sh
@@ -1,7 +1,12 @@
 #!/bin/sh
 
 if [ "$(mocp -Q %state)" != "STOP" ];then
-    echo "$(mocp -Q %song) - $(mocp -Q %album)"
+    SONG=$(mocp -Q %song)
+    if [ -z "$SONG" ]; then
+        basename "$(mocp -Q %file)"
+    else
+        echo "$SONG - $(mocp -Q %album)"
+    fi
 else
     echo ""
 fi


### PR DESCRIPTION
Not every file necessarily has the song field set to anything. In those
cases to avoid empty output, e.i. " - ", the filename is printed instead.