### PR TITLE
Travis refactor

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-language: c
+language: generic
 
 install:
   - scversion="stable"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,6 @@
 language: generic
 
-install:
-  - scversion="stable"
-  - wget "https://storage.googleapis.com/shellcheck/shellcheck-$scversion.linux.x86_64.tar.xz"
-  - tar --xz -xvf "shellcheck-$scversion.linux.x86_64.tar.xz"
-  - shellcheck() { "shellcheck-$scversion/shellcheck" "$@"; }
+dist: xenial
 
 before_script:
     - shellcheck --version


### PR DESCRIPTION
Just some travis optimizations I noticed could be done. Setting a generic language prevents travis from doing C specific stuff which we don't need. Not needing to download shellcheck should also speed up the process.