### PR TITLE
Fixes for fedora update checker

### DIFF
--- a/polybar-scripts/updates-fedora/updates-fedora.sh
+++ b/polybar-scripts/updates-fedora/updates-fedora.sh
@@ -2,8 +2,8 @@
 
 dnf=$(sudo dnf upgrade --refresh --assumeno 2> /dev/null)
 
-upgrade=$(echo "$dnf" | grep '^Upgrade' | awk '{ print $2 }')
-install=$(echo "$dnf" | grep '^Install' | awk '{ print $2 }')
+upgrade=$(echo "$dnf" | grep '^Upgrade ' | awk '{ print $2 }')
+install=$(echo "$dnf" | grep '^Install ' | awk '{ print $2 }')
 
 updates=$(( upgrade + install ))
 

--- a/polybar-scripts/updates-fedora/updates-fedora.sh
+++ b/polybar-scripts/updates-fedora/updates-fedora.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-dnf=$(dnf upgrade --refresh --assumeno 2> /dev/null)
+dnf=$(sudo dnf upgrade --refresh --assumeno 2> /dev/null)
 
 upgrade=$(echo "$dnf" | grep '^Upgrade' | awk '{ print $2 }')
 install=$(echo "$dnf" | grep '^Install' | awk '{ print $2 }')


### PR DESCRIPTION
FIXES:
* dnf upgrade needs sudo to be executed
* add space to remove the matching 'dependencies' string in $integer